### PR TITLE
Add token auth persistence and fix Linux HTML stats rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ __pycache__/
 received_events/
 *.html
 src/.github_token
+
+
+#Ignore vscode AI rules
+.github/instructions/codacy.instructions.md

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 received_events/
 *.html
 src/.github_token
+.codacy/
 
 
 #Ignore vscode AI rules

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 .vscode
 received_events/
 *.html
+src/.github_token

--- a/.pydocstyle
+++ b/.pydocstyle
@@ -1,2 +1,0 @@
-[pydocstyle]
-ignore = D211,D212

--- a/.pydocstyle
+++ b/.pydocstyle
@@ -1,0 +1,2 @@
+[pydocstyle]
+ignore = D211,D212

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 colorama==0.4.6
 PyQt5==5.15.11
 PyQt5_sip==12.15.0
-Requests==2.32.3
+Requests==2.33.0
 webview==0.1.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[pydocstyle]
+add-select = D203,D213
+ignore = D211,D212

--- a/src/core/utils.py
+++ b/src/core/utils.py
@@ -34,8 +34,7 @@ def get_auth_headers():
 
 
 def fetch_as_data_uri(url):
-    """
-    Fetch a remote image and return it as a base64 data URI.
+    """Fetch a remote image and return it as a base64 data URI.
 
     Embeds the image directly in the HTML file (needed when the page is served
     via file:// and WebKit would otherwise block external requests).

--- a/src/core/utils.py
+++ b/src/core/utils.py
@@ -34,7 +34,8 @@ def get_auth_headers():
 
 
 def fetch_as_data_uri(url):
-    """Fetch a remote image and return it as a base64 data URI.
+    """
+    Fetch a remote image and return it as a base64 data URI.
 
     Embeds the image directly in the HTML file (needed when the page is served
     via file:// and WebKit would otherwise block external requests).

--- a/src/core/utils.py
+++ b/src/core/utils.py
@@ -8,7 +8,6 @@ from requests.exceptions import HTTPError, RequestException
 
 
 class colors:
-
     """ANSI color constants used for terminal output."""
 
     HEADER = Fore.MAGENTA

--- a/src/core/utils.py
+++ b/src/core/utils.py
@@ -30,9 +30,11 @@ def get_auth_headers():
 
 
 def fetch_as_data_uri(url):
-    """Fetch a remote image and return it as a base64 data URI so it can be
-    embedded directly in the HTML file (needed when the page is served via
-    file:// and WebKit would otherwise block external requests)."""
+    """Fetch a remote image and return it as a base64 data URI.
+
+    Embeds the image directly in the HTML file (needed when the page is served
+    via file:// and WebKit would otherwise block external requests).
+    """
     try:
         resp = requests.get(url, timeout=15)
         resp.raise_for_status()

--- a/src/core/utils.py
+++ b/src/core/utils.py
@@ -1,3 +1,4 @@
+import base64
 import os
 import platform
 import requests
@@ -21,11 +22,32 @@ def clear():
     os.system("cls" if platform.system() == "Windows" else "clear")
 
 
+def get_auth_headers():
+    token = os.environ.get("GITHUB_TOKEN", "").strip()
+    if token:
+        return {"Authorization": f"Bearer {token}"}
+    return {}
+
+
+def fetch_as_data_uri(url):
+    """Fetch a remote image and return it as a base64 data URI so it can be
+    embedded directly in the HTML file (needed when the page is served via
+    file:// and WebKit would otherwise block external requests)."""
+    try:
+        resp = requests.get(url, timeout=15)
+        resp.raise_for_status()
+        content_type = resp.headers.get("Content-Type", "image/svg+xml").split(";")[0].strip()
+        encoded = base64.b64encode(resp.content).decode("ascii")
+        return f"data:{content_type};base64,{encoded}"
+    except Exception:
+        return url  # fall back to original URL on any failure
+
+
 def fetch_and_print_data(username):
     print(f"Fetching data for user: {colors.FAIL}{username}{colors.ENDC}")
     url = f"https://api.github.com/users/{username}"
     try:
-        response = requests.get(url, timeout=10)
+        response = requests.get(url, headers=get_auth_headers(), timeout=10)
         response.raise_for_status()
         data = response.json()
         print(f"\n{colors.WARNING}User Data:{colors.ENDC}")
@@ -65,7 +87,7 @@ def create_and_display_html_user_events(username, urls):
 
     url = f"https://api.github.com/users/{username}"
     try:
-        response = requests.get(url, timeout=10)
+        response = requests.get(url, headers=get_auth_headers(), timeout=10)
         response.raise_for_status()
         user_data = response.json()
 
@@ -90,7 +112,7 @@ def create_and_display_html_user_events(username, urls):
         os.remove(html_path)
 
     try:
-        response = requests.get(events_url, timeout=10)
+        response = requests.get(events_url, headers=get_auth_headers(), timeout=10)
         response.raise_for_status()
         events = response.json()
 
@@ -256,14 +278,18 @@ def create_and_display_html_user_events(username, urls):
                         avatar, login, event_type, repo_name,
                         repo_url, badge_class, action_text))
 
+            langs_src = fetch_as_data_uri(urls['mostUsedLanguages'])
+            stats_src = fetch_as_data_uri(urls['githubStats'])
+            streak_src = fetch_as_data_uri(urls['streakContributionsLS'])
+
             f.write(f"""</div>
     <div class="col-sm-12 col-md-4 col-lg-4">
         <h4 class="mb-4">Contribution Insights</h4>
         <div class="row justify-content-center align-items-left graph-container">
             <div class="col-12">
-                <img class="img-fluid w-100" src="{urls['mostUsedLanguages']}" alt="Top Languages">
-                <img class="img-fluid w-100" src="{urls['githubStats']}" alt="GitHub Stats">
-                <img class="img-fluid w-100" src="{urls['streakContributionsLS']}" alt="Streak Stats">
+                <img class="img-fluid w-100" src="{langs_src}" alt="Top Languages">
+                <img class="img-fluid w-100" src="{stats_src}" alt="GitHub Stats">
+                <img class="img-fluid w-100" src="{streak_src}" alt="Streak Stats">
             </div>
         </div>
     </div>

--- a/src/core/utils.py
+++ b/src/core/utils.py
@@ -7,7 +7,7 @@ from colorama import Fore, Style
 from requests.exceptions import HTTPError, RequestException
 
 
-class colors:  # pylint: disable=invalid-name,too-few-public-methods
+class colors:  # pylint: disable=invalid-name,too-few-public-methods  # noqa: D203,D211
     """ANSI color constants used for terminal output."""
 
     HEADER = Fore.MAGENTA
@@ -37,7 +37,7 @@ def get_auth_headers():
     return {}
 
 
-def fetch_as_data_uri(url):
+def fetch_as_data_uri(url):  # noqa: D212,D213
     """Fetch a remote image and return it as a base64 data URI.
 
     Embeds the image directly in the HTML file (needed when the page is served

--- a/src/core/utils.py
+++ b/src/core/utils.py
@@ -30,8 +30,7 @@ def get_auth_headers():
 
 
 def fetch_as_data_uri(url):
-    """
-    Fetch a remote image and return it as a base64 data URI.
+    """Fetch a remote image and return it as a base64 data URI.
 
     Embeds the image directly in the HTML file (needed when the page is served
     via file:// and WebKit would otherwise block external requests).

--- a/src/core/utils.py
+++ b/src/core/utils.py
@@ -93,47 +93,7 @@ def generate_html_event_row(avatar, login, event_type, repo_name, repo_url, badg
     </div>"""
 
 
-def create_and_display_html_user_events(username, urls):
-    """Build the user's HTML report from profile data and received events."""
-    events_url = f"https://api.github.com/users/{username}/received_events"
-    html_path = ".temp/index.html"
-
-    print(f"Generating HTML report... [{colors.GREEN}✓{colors.ENDC}]\n")
-
-    url = f"https://api.github.com/users/{username}"
-    try:
-        response = requests.get(url, headers=get_auth_headers(), timeout=10)
-        response.raise_for_status()
-        user_data = response.json()
-
-        login = user_data.get("login", "")
-        name = user_data.get("name", "")
-        location = user_data.get("location", "")
-        html_url = user_data.get("html_url", "")
-        avatar_url = user_data.get("avatar_url", "")
-        bio = user_data.get("bio", "")
-        followers = user_data.get("followers", 0)
-        following = user_data.get("following", 0)
-
-    except HTTPError as http_err:
-        print(f"{colors.FAIL}HTTP error occurred: {http_err}{colors.ENDC}")
-        return
-    except (RequestException, ValueError) as err:
-        print(f"{colors.FAIL}Unexpected error: {err}{colors.ENDC}")
-        return
-
-    os.makedirs(os.path.dirname(html_path), exist_ok=True)
-    if os.path.exists(html_path):
-        os.remove(html_path)
-
-    try:
-        response = requests.get(events_url, headers=get_auth_headers(), timeout=10)
-        response.raise_for_status()
-        events = response.json()
-
-        with open(html_path, "w", encoding="utf_8") as f:
-            f.write(f"""
-<!DOCTYPE html>
+HTML_REPORT_TEMPLATE = """<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
@@ -244,60 +204,16 @@ def create_and_display_html_user_events(username, urls):
                     Username: {login} <br>
                     About: {bio} <br>
                     Followers: {followers}, Following: {following} <br>
-                    Location: {location} 
+                    Location: {location}
                 </p>
                 <a href="{html_url}" class="btn btn-light" target="_blank">View Profile</a>
             </div>
         </div>
     </div>
     <div class="col-sm-12 col-md-8 col-lg-8">
-    <h4 class="mb-4">Received Events</h4>""")
-
-            for event in events:
-                event_type = event.get("type")
-                actor = event.get("actor", {})
-                payload = event.get("payload", {})
-                repo = event.get("repo", {})
-                login = actor.get("login", "")
-                avatar = actor.get("avatar_url", "")
-                repo_name = repo.get("name", "")
-                repo_url = f"https://github.com/{repo_name}"
-
-                badge_class = ""
-                action_text = ""
-
-                if event_type == "ForkEvent":
-                    badge_class = "text-danger"
-                    action_text = "Forked a repository"
-                    repo_url = payload.get("forkee", {}).get("html_url", "#")
-
-                elif event_type == "WatchEvent":
-                    badge_class = "text-warning"
-                    action_text = "Watch/Starred a repository"
-
-                elif event_type == "CreateEvent":
-                    badge_class = "text-success"
-                    action_text = "Created a repository"
-
-                elif event_type == "PublicEvent":
-                    badge_class = "text-primary"
-                    action_text = "Published a repository"
-
-                elif event_type == "ReleaseEvent":
-                    badge_class = "text-primary"
-                    action_text = "Released a repository"
-                    repo_url = payload.get("release", {}).get("html_url", "#")
-
-                if action_text:  # Only write if action_text is set
-                    f.write(generate_html_event_row(
-                        avatar, login, event_type, repo_name,
-                        repo_url, badge_class, action_text))
-
-            langs_src = fetch_as_data_uri(urls['mostUsedLanguages'])
-            stats_src = fetch_as_data_uri(urls['githubStats'])
-            streak_src = fetch_as_data_uri(urls['streakContributionsLS'])
-
-            f.write(f"""</div>
+    <h4 class="mb-4">Received Events</h4>
+{events_html}
+</div>
     <div class="col-sm-12 col-md-4 col-lg-4">
         <h4 class="mb-4">Contribution Insights</h4>
         <div class="row justify-content-center align-items-left graph-container">
@@ -311,7 +227,109 @@ def create_and_display_html_user_events(username, urls):
     </div>
 </body>
 </html>
-""")
+"""
+
+
+EVENT_ACTIONS = {
+    "WatchEvent": ("text-warning", "Watch/Starred a repository", None),
+    "CreateEvent": ("text-success", "Created a repository", None),
+    "PublicEvent": ("text-primary", "Published a repository", None),
+    "ForkEvent": ("text-danger", "Forked a repository", "forkee"),
+    "ReleaseEvent": ("text-primary", "Released a repository", "release"),
+}
+
+
+def _resolve_event_action(event_type, payload, repo_url):
+    """Return badge/action text and final URL for a GitHub event."""
+    action = EVENT_ACTIONS.get(event_type)
+    if not action:
+        return "", "", repo_url
+
+    badge_class, action_text, payload_key = action
+    if payload_key:
+        repo_url = payload.get(payload_key, {}).get("html_url", "#")
+
+    return badge_class, action_text, repo_url
+
+
+def _build_events_html(events):
+    """Return HTML rows for supported received event types."""
+    rows = []
+    for event in events:
+        event_type = event.get("type")
+        actor = event.get("actor", {})
+        payload = event.get("payload", {})
+        repo = event.get("repo", {})
+        login = actor.get("login", "")
+        avatar = actor.get("avatar_url", "")
+        repo_name = repo.get("name", "")
+        repo_url = f"https://github.com/{repo_name}"
+        badge_class, action_text, repo_url = _resolve_event_action(event_type, payload, repo_url)
+        if not action_text:
+            continue
+        rows.append(generate_html_event_row(
+            avatar,
+            login,
+            event_type,
+            repo_name,
+            repo_url,
+            badge_class,
+            action_text,
+        ))
+    return "".join(rows)
+
+
+def _build_report_html(user_data, events_html, urls):
+    """Render the final HTML report document as a single string."""
+    return HTML_REPORT_TEMPLATE.format(
+        login=user_data.get("login", ""),
+        name=user_data.get("name", ""),
+        location=user_data.get("location", ""),
+        html_url=user_data.get("html_url", ""),
+        avatar_url=user_data.get("avatar_url", ""),
+        bio=user_data.get("bio", ""),
+        followers=user_data.get("followers", 0),
+        following=user_data.get("following", 0),
+        events_html=events_html,
+        langs_src=fetch_as_data_uri(urls["mostUsedLanguages"]),
+        stats_src=fetch_as_data_uri(urls["githubStats"]),
+        streak_src=fetch_as_data_uri(urls["streakContributionsLS"]),
+    )
+
+
+def create_and_display_html_user_events(username, urls):
+    """Build the user's HTML report from profile data and received events."""
+    events_url = f"https://api.github.com/users/{username}/received_events"
+    html_path = ".temp/index.html"
+
+    print(f"Generating HTML report... [{colors.GREEN}✓{colors.ENDC}]\n")
+
+    url = f"https://api.github.com/users/{username}"
+    try:
+        user_response = requests.get(url, headers=get_auth_headers(), timeout=10)
+        user_response.raise_for_status()
+        user_data = user_response.json()
+
+    except HTTPError as http_err:
+        print(f"{colors.FAIL}HTTP error occurred: {http_err}{colors.ENDC}")
+        return
+    except (RequestException, ValueError) as err:
+        print(f"{colors.FAIL}Unexpected error: {err}{colors.ENDC}")
+        return
+
+    os.makedirs(os.path.dirname(html_path), exist_ok=True)
+    if os.path.exists(html_path):
+        os.remove(html_path)
+
+    try:
+        events_response = requests.get(events_url, headers=get_auth_headers(), timeout=10)
+        events_response.raise_for_status()
+        events = events_response.json()
+        events_html = _build_events_html(events)
+        report_html = _build_report_html(user_data, events_html, urls)
+
+        with open(html_path, "w", encoding="utf_8") as f:
+            f.write(report_html)
     except HTTPError as http_err:
         print(f"{colors.FAIL}HTTP error occurred: {http_err}{colors.ENDC}")
     except (RequestException, OSError, ValueError) as err:

--- a/src/core/utils.py
+++ b/src/core/utils.py
@@ -8,7 +8,6 @@ from requests.exceptions import HTTPError, RequestException
 
 
 class colors:
-
     """ANSI color constants used for terminal output."""
 
     HEADER = Fore.MAGENTA
@@ -39,7 +38,8 @@ def get_auth_headers():
 
 
 def fetch_as_data_uri(url):
-    """Fetch a remote image and return it as a base64 data URI.
+    """
+    Fetch a remote image and return it as a base64 data URI.
 
     Embeds the image directly in the HTML file (needed when the page is served
     via file:// and WebKit would otherwise block external requests).

--- a/src/core/utils.py
+++ b/src/core/utils.py
@@ -8,6 +8,7 @@ from requests.exceptions import HTTPError, RequestException
 
 
 class colors:  # pylint: disable=invalid-name,too-few-public-methods
+
     """ANSI color constants used for terminal output."""
 
     HEADER = Fore.MAGENTA
@@ -38,7 +39,8 @@ def get_auth_headers():
 
 
 def fetch_as_data_uri(url):
-    """Fetch a remote image and return it as a base64 data URI.
+    """
+    Fetch a remote image and return it as a base64 data URI.
 
     Embeds the image directly in the HTML file (needed when the page is served
     via file:// and WebKit would otherwise block external requests).

--- a/src/core/utils.py
+++ b/src/core/utils.py
@@ -8,6 +8,7 @@ from requests.exceptions import HTTPError, RequestException
 
 
 class colors:
+
     """ANSI color constants used for terminal output."""
 
     HEADER = Fore.MAGENTA
@@ -38,8 +39,7 @@ def get_auth_headers():
 
 
 def fetch_as_data_uri(url):
-    """
-    Fetch a remote image and return it as a base64 data URI.
+    """Fetch a remote image and return it as a base64 data URI.
 
     Embeds the image directly in the HTML file (needed when the page is served
     via file:// and WebKit would otherwise block external requests).

--- a/src/core/utils.py
+++ b/src/core/utils.py
@@ -3,7 +3,7 @@ import os
 import platform
 import requests
 from colorama import Fore, Style
-from requests.exceptions import HTTPError
+from requests.exceptions import HTTPError, RequestException
 
 
 class colors:
@@ -19,7 +19,11 @@ class colors:
 
 
 def clear():
-    os.system("cls" if platform.system() == "Windows" else "clear")
+    # Avoid spawning shell commands for terminal clear operations.
+    if platform.system() == "Windows":
+        print("\033[2J\033[H", end="")
+    else:
+        print("\033c", end="")
 
 
 def get_auth_headers():
@@ -42,7 +46,7 @@ def fetch_as_data_uri(url):
         content_type = resp.headers.get("Content-Type", "image/svg+xml").split(";")[0].strip()
         encoded = base64.b64encode(resp.content).decode("ascii")
         return f"data:{content_type};base64,{encoded}"
-    except Exception:
+    except (RequestException, ValueError, TypeError):
         return url  # fall back to original URL on any failure
 
 
@@ -60,7 +64,7 @@ def fetch_and_print_data(username):
 
     except HTTPError as http_err:
         print(f"{colors.FAIL}HTTP error occurred: {http_err}{colors.ENDC}")
-    except Exception as err:
+    except (RequestException, ValueError) as err:
         print(f"{colors.FAIL}Unexpected error: {err}{colors.ENDC}")
 
 
@@ -106,7 +110,7 @@ def create_and_display_html_user_events(username, urls):
     except HTTPError as http_err:
         print(f"{colors.FAIL}HTTP error occurred: {http_err}{colors.ENDC}")
         return
-    except Exception as err:
+    except (RequestException, ValueError) as err:
         print(f"{colors.FAIL}Unexpected error: {err}{colors.ENDC}")
         return
 
@@ -302,5 +306,5 @@ def create_and_display_html_user_events(username, urls):
 """)
     except HTTPError as http_err:
         print(f"{colors.FAIL}HTTP error occurred: {http_err}{colors.ENDC}")
-    except Exception as err:
+    except (RequestException, OSError, ValueError) as err:
         print(f"{colors.FAIL}Unexpected error: {err}{colors.ENDC}")

--- a/src/core/utils.py
+++ b/src/core/utils.py
@@ -8,7 +8,6 @@ from requests.exceptions import HTTPError, RequestException
 
 
 class colors:  # pylint: disable=invalid-name,too-few-public-methods
-
     """ANSI color constants used for terminal output."""
 
     HEADER = Fore.MAGENTA
@@ -39,8 +38,7 @@ def get_auth_headers():
 
 
 def fetch_as_data_uri(url):
-    """
-    Fetch a remote image and return it as a base64 data URI.
+    """Fetch a remote image and return it as a base64 data URI.
 
     Embeds the image directly in the HTML file (needed when the page is served
     via file:// and WebKit would otherwise block external requests).

--- a/src/core/utils.py
+++ b/src/core/utils.py
@@ -7,7 +7,7 @@ from colorama import Fore, Style
 from requests.exceptions import HTTPError, RequestException
 
 
-class colors:
+class colors:  # pylint: disable=invalid-name,too-few-public-methods
     """ANSI color constants used for terminal output."""
 
     HEADER = Fore.MAGENTA
@@ -72,14 +72,15 @@ def fetch_and_print_data(username):
         print(f"{colors.FAIL}Unexpected error: {err}{colors.ENDC}")
 
 
-def show_events_and_graphs(urls):
+def show_events_and_graphs():
     """Print a confirmation that graphs are available in the report."""
     print(
         f"\nGraphs available in Received Events [{colors.GREEN}✓{colors.ENDC}]"
     )
 
 
-def generate_html_event_row(avatar, login, event_type, repo_name, repo_url, badge_class, action_text):
+def generate_html_event_row(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    avatar, login, repo_name, repo_url, badge_class, action_text):
     """Return the HTML markup for a single received-event row."""
     return f"""
     <div class="event-row d-flex align-items-center shadow-sm">
@@ -269,7 +270,6 @@ def _build_events_html(events):
         rows.append(generate_html_event_row(
             avatar,
             login,
-            event_type,
             repo_name,
             repo_url,
             badge_class,
@@ -296,40 +296,55 @@ def _build_report_html(user_data, events_html, urls):
     )
 
 
-def create_and_display_html_user_events(username, urls):
-    """Build the user's HTML report from profile data and received events."""
-    events_url = f"https://api.github.com/users/{username}/received_events"
-    html_path = ".temp/index.html"
-
-    print(f"Generating HTML report... [{colors.GREEN}✓{colors.ENDC}]\n")
-
-    url = f"https://api.github.com/users/{username}"
+def _fetch_json(url):
+    """Fetch JSON from a URL and return parsed data, or None on failure."""
     try:
-        user_response = requests.get(url, headers=get_auth_headers(), timeout=10)
-        user_response.raise_for_status()
-        user_data = user_response.json()
-
+        response = requests.get(url, headers=get_auth_headers(), timeout=10)
+        response.raise_for_status()
+        return response.json()
     except HTTPError as http_err:
         print(f"{colors.FAIL}HTTP error occurred: {http_err}{colors.ENDC}")
-        return
     except (RequestException, ValueError) as err:
         print(f"{colors.FAIL}Unexpected error: {err}{colors.ENDC}")
-        return
+    return None
 
+
+def _prepare_output_path(html_path):
+    """Create output directory and remove any existing report file."""
     os.makedirs(os.path.dirname(html_path), exist_ok=True)
     if os.path.exists(html_path):
         os.remove(html_path)
 
-    try:
-        events_response = requests.get(events_url, headers=get_auth_headers(), timeout=10)
-        events_response.raise_for_status()
-        events = events_response.json()
-        events_html = _build_events_html(events)
-        report_html = _build_report_html(user_data, events_html, urls)
 
-        with open(html_path, "w", encoding="utf_8") as f:
-            f.write(report_html)
-    except HTTPError as http_err:
-        print(f"{colors.FAIL}HTTP error occurred: {http_err}{colors.ENDC}")
-    except (RequestException, OSError, ValueError) as err:
+def _write_report_file(html_path, report_html):
+    """Write report HTML to disk, returning True on success."""
+    try:
+        with open(html_path, "w", encoding="utf_8") as file_obj:
+            file_obj.write(report_html)
+        return True
+    except OSError as err:
         print(f"{colors.FAIL}Unexpected error: {err}{colors.ENDC}")
+    return False
+
+
+def create_and_display_html_user_events(username, urls):
+    """Build the user's HTML report from profile data and received events."""
+    user_url = f"https://api.github.com/users/{username}"
+    events_url = f"{user_url}/received_events"
+    html_path = ".temp/index.html"
+
+    print(f"Generating HTML report... [{colors.GREEN}✓{colors.ENDC}]\n")
+
+    user_data = _fetch_json(user_url)
+    if user_data is None:
+        return
+
+    events = _fetch_json(events_url)
+    if events is None:
+        return
+
+    _prepare_output_path(html_path)
+
+    events_html = _build_events_html(events)
+    report_html = _build_report_html(user_data, events_html, urls)
+    _write_report_file(html_path, report_html)

--- a/src/core/utils.py
+++ b/src/core/utils.py
@@ -1,3 +1,4 @@
+"""Shared helpers for fetching GitHub data and rendering the HTML report."""
 import base64
 import os
 import platform
@@ -7,6 +8,8 @@ from requests.exceptions import HTTPError, RequestException
 
 
 class colors:
+    """ANSI color constants used for terminal output."""
+
     HEADER = Fore.MAGENTA
     BLUE = Fore.BLUE
     CYAN = Fore.CYAN
@@ -19,7 +22,7 @@ class colors:
 
 
 def clear():
-    # Avoid spawning shell commands for terminal clear operations.
+    """Clear the terminal screen without spawning a shell."""
     if platform.system() == "Windows":
         print("\033[2J\033[H", end="")
     else:
@@ -27,6 +30,7 @@ def clear():
 
 
 def get_auth_headers():
+    """Return the Authorization header dict if a GitHub token is set."""
     token = os.environ.get("GITHUB_TOKEN", "").strip()
     if token:
         return {"Authorization": f"Bearer {token}"}
@@ -51,6 +55,7 @@ def fetch_as_data_uri(url):
 
 
 def fetch_and_print_data(username):
+    """Fetch the GitHub user profile and print each field to the terminal."""
     print(f"Fetching data for user: {colors.FAIL}{username}{colors.ENDC}")
     url = f"https://api.github.com/users/{username}"
     try:
@@ -69,12 +74,14 @@ def fetch_and_print_data(username):
 
 
 def show_events_and_graphs(urls):
+    """Print a confirmation that graphs are available in the report."""
     print(
         f"\nGraphs available in Received Events [{colors.GREEN}✓{colors.ENDC}]"
     )
 
 
 def generate_html_event_row(avatar, login, event_type, repo_name, repo_url, badge_class, action_text):
+    """Return the HTML markup for a single received-event row."""
     return f"""
     <div class="event-row d-flex align-items-center shadow-sm">
         <img src="{avatar}" class="profile-picture me-3" alt="Avatar of {login}">
@@ -87,6 +94,7 @@ def generate_html_event_row(avatar, login, event_type, repo_name, repo_url, badg
 
 
 def create_and_display_html_user_events(username, urls):
+    """Build the user's HTML report from profile data and received events."""
     events_url = f"https://api.github.com/users/{username}/received_events"
     html_path = ".temp/index.html"
 

--- a/src/core/utils.py
+++ b/src/core/utils.py
@@ -30,7 +30,8 @@ def get_auth_headers():
 
 
 def fetch_as_data_uri(url):
-    """Fetch a remote image and return it as a base64 data URI.
+    """
+    Fetch a remote image and return it as a base64 data URI.
 
     Embeds the image directly in the HTML file (needed when the page is served
     via file:// and WebKit would otherwise block external requests).

--- a/src/htmlviewers/linux.py
+++ b/src/htmlviewers/linux.py
@@ -1,3 +1,4 @@
+"""Linux HTML viewer backed by pywebview/WebKit."""
 import webview  # type: ignore
 import os
 import sys
@@ -9,7 +10,7 @@ os.environ.setdefault("GALLIUM_DRIVER", "llvmpipe")
 
 
 def showHTMLLinux():
-    # Functions & Global Variables
+    """Open the generated HTML report in a pywebview window."""
     app_name = "GitHubUserDataExtractor - HTML Viewer"
     html_file = os.path.abspath(os.path.join(
         ".temp", "index.html"))

--- a/src/htmlviewers/linux.py
+++ b/src/htmlviewers/linux.py
@@ -1,7 +1,7 @@
 """Linux HTML viewer backed by pywebview/WebKit."""
-import webview  # type: ignore
 import os
 import sys
+import webview  # type: ignore
 
 # Suppress dconf "no database" warnings from GTK/WebKit
 os.environ.setdefault("DCONF_PROFILE", "/dev/null")
@@ -9,7 +9,7 @@ os.environ.setdefault("DCONF_PROFILE", "/dev/null")
 os.environ.setdefault("GALLIUM_DRIVER", "llvmpipe")
 
 
-def showHTMLLinux():
+def show_html_linux():
     """Open the generated HTML report in a pywebview window."""
     app_name = "GitHubUserDataExtractor - HTML Viewer"
     html_file = os.path.abspath(os.path.join(

--- a/src/htmlviewers/linux.py
+++ b/src/htmlviewers/linux.py
@@ -2,12 +2,17 @@ import webview  # type: ignore
 import os
 import sys
 
+# Suppress dconf "no database" warnings from GTK/WebKit
+os.environ.setdefault("DCONF_PROFILE", "/dev/null")
+# Suppress MESA ZINK (Vulkan-backed OpenGL) errors — fall back to software renderer
+os.environ.setdefault("GALLIUM_DRIVER", "llvmpipe")
+
 
 def showHTMLLinux():
     # Functions & Global Variables
     app_name = "GitHubUserDataExtractor - HTML Viewer"
     html_file = os.path.abspath(os.path.join(
-        "Data", "ReceivedEvents", "index.html"))
+        ".temp", "index.html"))
 
     # Check if the file exists
     if not os.path.exists(html_file):

--- a/src/htmlviewers/win.py
+++ b/src/htmlviewers/win.py
@@ -7,7 +7,6 @@ from PyQt5.QtWebEngineWidgets import QWebEngineView
 
 
 class HTMLViewer(QMainWindow):
-
     """Main window that renders the generated HTML report."""
 
     def __init__(self, html_path):

--- a/src/htmlviewers/win.py
+++ b/src/htmlviewers/win.py
@@ -1,3 +1,4 @@
+"""Windows HTML viewer backed by PyQt5 QWebEngineView."""
 import sys
 import os
 from PyQt5.QtCore import QUrl
@@ -6,7 +7,10 @@ from PyQt5.QtWebEngineWidgets import QWebEngineView
 
 
 class HTMLViewer(QMainWindow):
+    """Main window that renders the generated HTML report."""
+
     def __init__(self, html_path):
+        """Initialize the viewer window for the given HTML file path."""
         super().__init__()
         self.setWindowTitle("GitHubUserDataExtractor - HTML Viewer")
 
@@ -46,7 +50,7 @@ class HTMLViewer(QMainWindow):
 
 
 def showHTMLWindow():
-    """Launches the PyQt5 application to display the HTML content."""
+    """Launch the PyQt5 application and display the HTML content."""
     app = QApplication(sys.argv)
 
     # Absolute path to the HTML file

--- a/src/htmlviewers/win.py
+++ b/src/htmlviewers/win.py
@@ -2,11 +2,13 @@
 import sys
 import os
 from PyQt5.QtCore import QUrl
-from PyQt5.QtWidgets import QApplication, QMainWindow, QVBoxLayout, QWidget, QMessageBox, QDesktopWidget
+from PyQt5.QtWidgets import (
+    QApplication, QMainWindow, QVBoxLayout, QWidget, QMessageBox, QDesktopWidget
+)
 from PyQt5.QtWebEngineWidgets import QWebEngineView
 
 
-class HTMLViewer(QMainWindow):
+class HTMLViewer(QMainWindow):  # pylint: disable=too-few-public-methods
     """Main window that renders the generated HTML report."""
 
     def __init__(self, html_path):
@@ -49,7 +51,7 @@ class HTMLViewer(QMainWindow):
         self.move(frame_geometry.topLeft())
 
 
-def showHTMLWindow():
+def show_html_window():
     """Launch the PyQt5 application and display the HTML content."""
     app = QApplication(sys.argv)
 

--- a/src/htmlviewers/win.py
+++ b/src/htmlviewers/win.py
@@ -8,7 +8,7 @@ from PyQt5.QtWidgets import (
 from PyQt5.QtWebEngineWidgets import QWebEngineView
 
 
-class HTMLViewer(QMainWindow):  # pylint: disable=too-few-public-methods
+class HTMLViewer(QMainWindow):  # pylint: disable=too-few-public-methods  # noqa: D203,D211
     """Main window that renders the generated HTML report."""
 
     def __init__(self, html_path):

--- a/src/htmlviewers/win.py
+++ b/src/htmlviewers/win.py
@@ -60,8 +60,8 @@ def showHTMLWindow():
     browser = HTMLViewer(html_file_path)
     browser.show()
 
-    # Execute the application and ensure proper exit
-    sys.exit(app.exec_())
+    # Execute the application and capture the exit code so cleanup can run.
+    exit_code = app.exec_()
 
     # Delete the HTML file after closing the viewer
     try:
@@ -70,3 +70,6 @@ def showHTMLWindow():
         print(f"Warning: HTML file '{html_file_path}' not found to delete.")
     except OSError as e:
         print(f"Error deleting HTML file: {e}")
+
+    # Exit with the same code returned by Qt.
+    sys.exit(exit_code)

--- a/src/htmlviewers/win.py
+++ b/src/htmlviewers/win.py
@@ -9,6 +9,7 @@ from PyQt5.QtWebEngineWidgets import QWebEngineView
 
 
 class HTMLViewer(QMainWindow):  # pylint: disable=too-few-public-methods
+
     """Main window that renders the generated HTML report."""
 
     def __init__(self, html_path):

--- a/src/htmlviewers/win.py
+++ b/src/htmlviewers/win.py
@@ -7,6 +7,7 @@ from PyQt5.QtWebEngineWidgets import QWebEngineView
 
 
 class HTMLViewer(QMainWindow):
+
     """Main window that renders the generated HTML report."""
 
     def __init__(self, html_path):

--- a/src/htmlviewers/win.py
+++ b/src/htmlviewers/win.py
@@ -9,7 +9,6 @@ from PyQt5.QtWebEngineWidgets import QWebEngineView
 
 
 class HTMLViewer(QMainWindow):  # pylint: disable=too-few-public-methods
-
     """Main window that renders the generated HTML report."""
 
     def __init__(self, html_path):

--- a/src/htmlviewers/win.py
+++ b/src/htmlviewers/win.py
@@ -64,5 +64,5 @@ def showHTMLWindow():
         os.remove(html_file_path)
     except FileNotFoundError:
         print(f"Warning: HTML file '{html_file_path}' not found to delete.")
-    except Exception as e:
+    except OSError as e:
         print(f"Error deleting HTML file: {e}")

--- a/src/main.py
+++ b/src/main.py
@@ -1,16 +1,12 @@
 import os
+import sys
 import platform
 import core.utils as session
 from core.utils import colors
 
-if platform.system() == "Windows":
-    import htmlviewers.win as windows
-else:
-    import htmlviewers.linux as linux
-
 
 def display_banner():
-    os.system("cls" if platform.system() == "Windows" else "clear")
+    session.clear()
     banner = r'''
   ____ _ _   _   _       _       _   _                 ____        _
  / ___(_) |_| | | |_   _| |__   | | | |___  ___ _ __  |  _ \  __ _| |_ __ _
@@ -65,10 +61,10 @@ def get_username():
     print(colors.ENDC, end="")
     if not username:
         print(f"{colors.RED}Username cannot be empty!{colors.ENDC}")
-        exit(1)
+        sys.exit(1)
     if username == "exit":
         print(colors.RED + 'Bye.' + colors.ENDC)
-        exit(0)
+        sys.exit(0)
     return username
 
 
@@ -86,12 +82,14 @@ def open_html_viewer():
     html_file = os.path.join(".temp", "index.html")
     if platform.system() == "Linux":
         try:
+            import htmlviewers.linux as linux
             linux.showHTMLLinux()
         except ImportError:
             print(
                 f"{colors.RED}Error: HTMLViewer_Linux module not found.{colors.ENDC}")
     elif platform.system() == "Windows":
         try:
+            import htmlviewers.win as windows
             windows.showHTMLWindow()
         except ImportError:
             print(

--- a/src/main.py
+++ b/src/main.py
@@ -90,11 +90,25 @@ def get_username():
 def get_stat_urls(username):
     """Return the mapping of stat-card URLs for the given username."""
     return {
-        "mostUsedLanguages": f"https://github-profile-summary-cards.vercel.app/api/cards/repos-per-language?username={username}&theme=dark",  # pylint: disable=line-too-long
-        "githubStats": f"https://github-profile-summary-cards.vercel.app/api/cards/stats?username={username}&theme=dark",  # pylint: disable=line-too-long
+        "mostUsedLanguages": (
+            "https://github-profile-summary-cards.vercel.app/api/cards/repos-per-language"
+            f"?username={username}&theme=dark"
+        ),
+        "githubStats": (
+            "https://github-profile-summary-cards.vercel.app/api/cards/stats"
+            f"?username={username}&theme=dark"
+        ),
         "streakContributionsLS": f"https://streak-stats.demolab.com/?user={username}",
-        "contributorGraphOne": f"https://github-readme-activity-graph.vercel.app/graph?username={username}&bg_color=000000&color=ffffff&line=ffffff&point=ffffff&area=true&hide_border=true",  # pylint: disable=line-too-long
-        "contributorGraphTwo": f"https://github-profile-summary-cards.vercel.app/api/cards/profile-details?username={username}&theme=dark"  # pylint: disable=line-too-long
+        "contributorGraphOne": (
+            "https://github-readme-activity-graph.vercel.app/graph"
+            f"?username={username}"
+            "&bg_color=000000&color=ffffff&line=ffffff"
+            "&point=ffffff&area=true&hide_border=true"
+        ),
+        "contributorGraphTwo": (
+            "https://github-profile-summary-cards.vercel.app/api/cards/profile-details"
+            f"?username={username}&theme=dark"
+        ),
     }
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -45,7 +45,8 @@ def prompt_for_token():
     saved = load_saved_token()
     if saved:
         os.environ["GITHUB_TOKEN"] = saved
-        print(f"{colors.GREEN}Saved token loaded — authenticated rate limit active (5,000 req/hr).{colors.ENDC}\n")
+        print(f"{colors.GREEN}Saved token loaded — "
+               f"authenticated rate limit active (5,000 req/hr).{colors.ENDC}\n")
         return
 
     token = input(
@@ -55,9 +56,11 @@ def prompt_for_token():
     if token:
         os.environ["GITHUB_TOKEN"] = token
         save_token(token)
-        print(f"{colors.GREEN}Token set and saved — authenticated rate limit active (5,000 req/hr).{colors.ENDC}\n")
+        print(f"{colors.GREEN}Token set and saved — "
+               f"authenticated rate limit active (5,000 req/hr).{colors.ENDC}\n")
     else:
-        print(f"{colors.WARNING}No token provided — unauthenticated rate limit applies (60 req/hr).{colors.ENDC}\n")
+        print(f"{colors.WARNING}No token provided — "
+               f"unauthenticated rate limit applies (60 req/hr).{colors.ENDC}\n")
 
 
 def get_username():
@@ -77,11 +80,11 @@ def get_username():
 def get_stat_urls(username):
     """Return the mapping of stat-card URLs for the given username."""
     return {
-        "mostUsedLanguages": f"https://github-profile-summary-cards.vercel.app/api/cards/repos-per-language?username={username}&theme=dark",
-        "githubStats": f"https://github-profile-summary-cards.vercel.app/api/cards/stats?username={username}&theme=dark",
+        "mostUsedLanguages": f"https://github-profile-summary-cards.vercel.app/api/cards/repos-per-language?username={username}&theme=dark",  # pylint: disable=line-too-long
+        "githubStats": f"https://github-profile-summary-cards.vercel.app/api/cards/stats?username={username}&theme=dark",  # pylint: disable=line-too-long
         "streakContributionsLS": f"https://streak-stats.demolab.com/?user={username}",
-        "contributorGraphOne": f"https://github-readme-activity-graph.vercel.app/graph?username={username}&bg_color=000000&color=ffffff&line=ffffff&point=ffffff&area=true&hide_border=true",
-        "contributorGraphTwo": f"https://github-profile-summary-cards.vercel.app/api/cards/profile-details?username={username}&theme=dark"
+        "contributorGraphOne": f"https://github-readme-activity-graph.vercel.app/graph?username={username}&bg_color=000000&color=ffffff&line=ffffff&point=ffffff&area=true&hide_border=true",  # pylint: disable=line-too-long
+        "contributorGraphTwo": f"https://github-profile-summary-cards.vercel.app/api/cards/profile-details?username={username}&theme=dark"  # pylint: disable=line-too-long
     }
 
 
@@ -90,15 +93,15 @@ def open_html_viewer():
     html_file = os.path.join(".temp", "index.html")
     if platform.system() == "Linux":
         try:
-            import htmlviewers.linux as linux
-            linux.showHTMLLinux()
+            from htmlviewers import linux  # pylint: disable=import-outside-toplevel
+            linux.show_html_linux()
         except ImportError:
             print(
                 f"{colors.RED}Error: HTMLViewer_Linux module not found.{colors.ENDC}")
     elif platform.system() == "Windows":
         try:
-            import htmlviewers.win as windows
-            windows.showHTMLWindow()
+            from htmlviewers import win as windows  # pylint: disable=import-outside-toplevel
+            windows.show_html_window()
         except ImportError:
             print(
                 f"{colors.RED}Error: HTMLViewer_Windows module not found.{colors.ENDC}")
@@ -121,7 +124,7 @@ def main():
     urls = get_stat_urls(username)
 
     session.fetch_and_print_data(username)
-    session.show_events_and_graphs(urls)
+    session.show_events_and_graphs()
     session.create_and_display_html_user_events(username, urls)
     open_html_viewer()
 

--- a/src/main.py
+++ b/src/main.py
@@ -24,6 +24,41 @@ def display_banner():
         f"Website  : {colors.CYAN}https://quantumbytestudios.in{colors.ENDC}\n")
 
 
+TOKEN_FILE = os.path.join(os.path.dirname(__file__), ".github_token")
+
+
+def load_saved_token():
+    try:
+        with open(TOKEN_FILE, "r", encoding="utf-8") as f:
+            return f.read().strip()
+    except FileNotFoundError:
+        return ""
+
+
+def save_token(token):
+    with open(TOKEN_FILE, "w", encoding="utf-8") as f:
+        f.write(token)
+
+
+def prompt_for_token():
+    saved = load_saved_token()
+    if saved:
+        os.environ["GITHUB_TOKEN"] = saved
+        print(f"{colors.GREEN}Saved token loaded — authenticated rate limit active (5,000 req/hr).{colors.ENDC}\n")
+        return
+
+    token = input(
+        f"Enter a GitHub Access Token (leave blank to use unauthenticated): {colors.WARNING}"
+    ).strip()
+    print(colors.ENDC, end="")
+    if token:
+        os.environ["GITHUB_TOKEN"] = token
+        save_token(token)
+        print(f"{colors.GREEN}Token set and saved — authenticated rate limit active (5,000 req/hr).{colors.ENDC}\n")
+    else:
+        print(f"{colors.WARNING}No token provided — unauthenticated rate limit applies (60 req/hr).{colors.ENDC}\n")
+
+
 def get_username():
     username = input(
         f"Enter a GitHub Username: {colors.WARNING}").strip().lower()
@@ -39,8 +74,8 @@ def get_username():
 
 def get_stat_urls(username):
     return {
-        "mostUsedLanguages": f"https://github-readme-stats.vercel.app/api/top-langs?username={username}&langs_count=8",
-        "githubStats": f"https://github-readme-stats.vercel.app/api?username={username}&show_icons=true&locale=en",
+        "mostUsedLanguages": f"https://github-profile-summary-cards.vercel.app/api/cards/repos-per-language?username={username}&theme=dark",
+        "githubStats": f"https://github-profile-summary-cards.vercel.app/api/cards/stats?username={username}&theme=dark",
         "streakContributionsLS": f"https://streak-stats.demolab.com/?user={username}",
         "contributorGraphOne": f"https://github-readme-activity-graph.vercel.app/graph?username={username}&bg_color=000000&color=ffffff&line=ffffff&point=ffffff&area=true&hide_border=true",
         "contributorGraphTwo": f"https://github-profile-summary-cards.vercel.app/api/cards/profile-details?username={username}&theme=dark"
@@ -74,6 +109,7 @@ def open_html_viewer():
 
 def main():
     display_banner()
+    prompt_for_token()
     username = get_username()
     urls = get_stat_urls(username)
 

--- a/src/main.py
+++ b/src/main.py
@@ -1,3 +1,4 @@
+"""Entry point for the GitHub User Data Extractor CLI."""
 import os
 import sys
 import platform
@@ -6,6 +7,7 @@ from core.utils import colors
 
 
 def display_banner():
+    """Print the application banner and developer credits."""
     session.clear()
     banner = r'''
   ____ _ _   _   _       _       _   _                 ____        _
@@ -24,6 +26,7 @@ TOKEN_FILE = os.path.join(os.path.dirname(__file__), ".github_token")
 
 
 def load_saved_token():
+    """Return the GitHub token persisted on disk, or an empty string."""
     try:
         with open(TOKEN_FILE, "r", encoding="utf-8") as f:
             return f.read().strip()
@@ -32,11 +35,13 @@ def load_saved_token():
 
 
 def save_token(token):
+    """Persist the supplied GitHub token to the token file."""
     with open(TOKEN_FILE, "w", encoding="utf-8") as f:
         f.write(token)
 
 
 def prompt_for_token():
+    """Load a saved token or prompt the user for a new one."""
     saved = load_saved_token()
     if saved:
         os.environ["GITHUB_TOKEN"] = saved
@@ -56,6 +61,7 @@ def prompt_for_token():
 
 
 def get_username():
+    """Prompt for and return a non-empty GitHub username."""
     username = input(
         f"Enter a GitHub Username: {colors.WARNING}").strip().lower()
     print(colors.ENDC, end="")
@@ -69,6 +75,7 @@ def get_username():
 
 
 def get_stat_urls(username):
+    """Return the mapping of stat-card URLs for the given username."""
     return {
         "mostUsedLanguages": f"https://github-profile-summary-cards.vercel.app/api/cards/repos-per-language?username={username}&theme=dark",
         "githubStats": f"https://github-profile-summary-cards.vercel.app/api/cards/stats?username={username}&theme=dark",
@@ -79,6 +86,7 @@ def get_stat_urls(username):
 
 
 def open_html_viewer():
+    """Open the generated HTML report in the platform-specific viewer."""
     html_file = os.path.join(".temp", "index.html")
     if platform.system() == "Linux":
         try:
@@ -106,6 +114,7 @@ def open_html_viewer():
 
 
 def main():
+    """Run the full extraction workflow end-to-end."""
     display_banner()
     prompt_for_token()
     username = get_username()

--- a/src/main.py
+++ b/src/main.py
@@ -22,7 +22,9 @@ def display_banner():
         f"Website  : {colors.CYAN}https://quantumbytestudios.in{colors.ENDC}\n")
 
 
-TOKEN_FILE = os.path.join(os.path.dirname(__file__), ".github_token")
+TOKEN_DIR = os.path.join(os.path.expanduser("~"), ".config", "githubuserdataextractor")
+TOKEN_FILE = os.path.join(TOKEN_DIR, "github_token")
+LEGACY_TOKEN_FILE = os.path.join(os.path.dirname(__file__), ".github_token")
 
 
 def load_saved_token():
@@ -31,11 +33,19 @@ def load_saved_token():
         with open(TOKEN_FILE, "r", encoding="utf-8") as f:
             return f.read().strip()
     except FileNotFoundError:
-        return ""
+        try:
+            with open(LEGACY_TOKEN_FILE, "r", encoding="utf-8") as f:
+                token = f.read().strip()
+            if token:
+                save_token(token)
+            return token
+        except FileNotFoundError:
+            return ""
 
 
 def save_token(token):
     """Persist the supplied GitHub token to the token file."""
+    os.makedirs(TOKEN_DIR, exist_ok=True)
     with open(TOKEN_FILE, "w", encoding="utf-8") as f:
         f.write(token)
 


### PR DESCRIPTION
## Overview

This PR improves reliability, usability, and Linux compatibility for GitHub user data extraction and HTML report viewing.

---

## Highlights

- Added authenticated GitHub API support via personal access token.
- Persisted token across runs using a local token file.
- Fixed Linux HTML viewer path so the generated report opens correctly.
- Suppressed noisy dconf and MESA startup warnings in Linux viewer flow.
- Fixed broken stats images by embedding fetched images as base64 data URIs.
- Replaced paused stats endpoints with working alternatives.

---

## What Changed

### Authentication and Rate Limits
- Added authenticated request headers when `GITHUB_TOKEN` is present.
- Kept graceful fallback behavior when no token is provided.

### Token Persistence
- Added token load and save flow in startup prompt logic.
- Added local token file to git ignore rules to avoid accidental secret commits.

### Linux Viewer Reliability
- Updated Linux viewer to open the generated `index.html` through an absolute path.
- Added Linux environment defaults to reduce terminal warning noise.

### Stats Rendering Fixes
- Added fetch + base64 data URI fallback for stats images.
- Switched Top Languages and GitHub Stats providers to `github-profile-summary-cards` endpoints.

---

## Why These Changes

- Unauthenticated GitHub API usage quickly hits strict rate limits.
- Re-entering a token every run is inconvenient.
- Linux viewer had path and startup noise issues.
- External image URLs can fail under local file rendering; data URIs improve consistency.
- Previous stats provider endpoint was paused and caused broken image sections.

---

## Validation

- Ran the application successfully on Linux.
- Confirmed token is loaded from saved file on subsequent runs.
- Confirmed HTML report generation and viewer launch flow.
- Confirmed Top Languages, GitHub Stats, and Streak sections render correctly in the local viewer.

---

## Notes

- Existing unauthenticated behavior is preserved if no token is provided.
- Token file remains local and untracked by git.